### PR TITLE
fix: ssl/tls alert handshake failure in Python 3.10 and use the configuration items on the control error output

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -19,10 +19,10 @@ from pypinyin import Style, pinyin
 from hoshino import HoshinoBot, Service, priv
 from hoshino.aiorequests import run_sync_func
 from hoshino.typing import CQEvent, MessageSegment, Message
-from .config import meme_command_start
+from .config import meme_command_start, memes_prompt_params_error
 from .data_source import ImageSource, UserInfo
 from .depends import split_msg_v11
-from .exception import NetworkError, PlatformUnsupportError
+from .exception import NetworkError
 from .manager import ActionResult, MemeMode, meme_manager
 from .utils import meme_info, bytesio2b64
 
@@ -228,7 +228,9 @@ async def process(
     try:
         result = await run_sync_func(meme, images=images, texts=texts, args=args)
     except MemeGeneratorException as e:
-        await bot.send(ev, e.message)
+        if memes_prompt_params_error:
+            await bot.send(ev, e.message)
+        sv.logger.warning(meme.key, e.message)
         return
 
     try:

--- a/data_source/utils.py
+++ b/data_source/utils.py
@@ -4,7 +4,7 @@ from typing import Union
 
 from aiohttp import ClientSession
 
-from hoshino import logger
+from hoshino import aiorequests, logger
 from .exception import NetworkError
 
 headers = {
@@ -19,9 +19,8 @@ async def get_content(url: str, session: ClientSession) -> Union[Exception, byte
         async with session.get(url, headers=headers) as resp:
             return await resp.content.read()
     except Exception as e:
-        logger.error(f"aiorequest error: {e}")
-        return e
-
+        logger.warning(f"aiorequest error: {e}")
+        return await (await aiorequests.get(url)).content
 
 async def download_url(url: str) -> bytes:
     async with ClientSession() as session:


### PR DESCRIPTION
添加 Hoshino 自己的 aoirequest 作为 fallback，这样在遇到请求失败的时候可以使用它作为尝试
使用上了配置文件中的 memes_prompt_params_error 来实际控制参数解析的错误输出